### PR TITLE
Changed the React Native imports to follow the pattern started with RN 0.25

### DIFF
--- a/Triangle.js
+++ b/Triangle.js
@@ -1,10 +1,10 @@
 'use strict';
 
- var React = require('react-native');
- var {
-   StyleSheet,
-   View,
- } = React;
+import React from 'react';
+import {
+  StyleSheet,
+  View
+} from 'react-native';
 
  var Triangle = React.createClass({
 


### PR DESCRIPTION
We are using your package in our project (thanks for making this package!)

We are getting our project ready to upgrade to RN 0.26, and your library is failing because of a change that was made in RN 0.25. See https://github.com/facebook/react-native/releases/tag/v0.25.1, quoted below:

Requiring React API from react-native is now deprecated

Instead of:

import React, { Component, View } from 'react-native';
you should now:

import React, { Component } from 'react';
import { View } from 'react-native';

The change is only deprecated in 0.25, but it is going to be required in RN 0.26.