### PR TITLE
fix: missing displayName

### DIFF
--- a/Triangle.js
+++ b/Triangle.js
@@ -9,6 +9,8 @@ var createReactClass = require('create-react-class');
 var PropTypes = require('prop-types')
 
  var Triangle = createReactClass({
+   
+   displayName: 'Triangle',
 
    propTypes: {
      direction: PropTypes.oneOf(['up', 'right', 'down', 'left', 'up-right', 'up-left', 'down-right', 'down-left']),


### PR DESCRIPTION
The createReactClass function doesn't automatically set the displayName anymore which leads to jest snapshots looking like the following, where the component gets identified as `Unknown`.

```
@@ -222,11 +222,11 @@
                             "marginHorizontal": 50,
                             "marginVertical": 30,
                           }
                     }
                 >
    -                <Triangle
    +                <Unknown
                         color="#C9C7C1"
                         direction="down"
                         height={17}
                         width={25}
                     />
```